### PR TITLE
[FEAT] 검색 결과 타이틀 컴포넌트 구현 #50

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,50 @@
 import { Global, ThemeProvider, css } from '@emotion/react';
 import theme from '@styles/theme';
 import GlobalStyle from './styles/global';
-import ProductTag from './components/Tag/ProductTag';
-import { productTags } from './components/Tag/tagData';
+import SearchResultTitle from './components/searchResultTitle/SearchResultTitle';
 
 function App() {
   return (
     <>
       <ThemeProvider theme={theme}>
         <Global styles={GlobalStyle} />
-        <div css={css`
-          display: inline-flex;
-          align-items: center;
-          gap: 0.4rem;
-        `}>
-          {productTags.map((tag, idx) => (
-            <ProductTag key={idx} {...tag} />
-          ))}
+        
+        {/* SearchResultTitle 테스트 */}
+        <div 
+          css={css`
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 40px;
+          `}
+        >
+          {/* 정렬 옵션이 있는 경우 */}
+          <div 
+            css={css`
+              margin: 24px 16px;
+            `}
+          >
+            <h3 css={css`${theme.fonts['heading-16B']} margin-bottom: 16px;`}>
+              검색 결과 타이틀 (정렬 옵션 있음)
+            </h3>
+            <SearchResultTitle 
+              totalCount={19} 
+              showSortOptions={true}
+              onSortChange={() => {}}
+            />
+          </div>
+
+          {/* 개수만 표시하는 경우 */}
+          <div 
+            css={css`
+              margin: 24px 16px;
+            `}
+          >
+            <h3 css={css`${theme.fonts['heading-16B']} margin-bottom: 16px;`}>
+              재고 정보 타이틀 (개수만 표시)
+            </h3>
+            <SearchResultTitle totalCount={3} />
+          </div>
         </div>
       </ThemeProvider>
     </>

--- a/src/components/searchResultTitle/SearchResultTitle.style.ts
+++ b/src/components/searchResultTitle/SearchResultTitle.style.ts
@@ -1,0 +1,82 @@
+import { css } from '@emotion/react';
+import theme from '@styles/theme';
+
+export const containerStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  
+  width: 343px;
+`;
+
+export const countTextStyle = css`
+  ${theme.fonts['heading-14B']}
+  
+  color: ${theme.colors.black};
+`;
+
+export const sortContainerStyle = css`
+  display: flex;
+  align-items: center;
+  
+  background: none;
+  border: none;
+  padding: 0;
+  
+  cursor: pointer;
+`;
+
+export const sortTextStyle = css`
+  ${theme.fonts['button-14R']}
+  
+  color: ${theme.colors['gray-01']};
+`;
+
+export const iconContainerStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  
+  width: 24px;
+  height: 24px;
+  padding: 0px 7px;
+`;
+
+export const iconStyle = css``;
+
+export const sortOptionsContainerStyle = css`
+  position: relative;
+`;
+
+export const dropdownStyle = css`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  
+  margin-top: 8px;
+  width: 120px;
+  
+  background-color: ${theme.colors.white};
+  border-radius: 4px;
+  
+  overflow: hidden;
+  z-index: 10;
+`;
+
+export const optionButtonStyle = (isSelected: boolean) => css`
+  width: 100%;
+  padding: 12px 16px;
+  
+  text-align: left;
+  background: none;
+  border: none;
+  
+  ${theme.fonts['body-14R']}
+  color: ${isSelected ? theme.colors.primary : theme.colors['gray-01']};
+  
+  cursor: pointer;
+  
+  &:hover {
+    background-color: ${theme.colors['gray-06']};
+  }
+`;

--- a/src/components/searchResultTitle/SearchResultTitle.tsx
+++ b/src/components/searchResultTitle/SearchResultTitle.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import * as S from './SearchResultTitle.style';
+import SmallArrowDownIcon from '@assets/svgs/SmallArrowDownIcon';
+
+// 정렬 옵션 타입 정의
+type SortOption = '신상품' | '가격높은' | '가격낮은';
+
+// 정렬 옵션 목록
+const SORT_OPTIONS: SortOption[] = [
+  '신상품',
+  '가격높은',
+  '가격낮은'
+];
+
+interface SearchResultTitleProps {
+  totalCount: number;
+  initialSortOption?: SortOption;
+  onSortChange?: (option: SortOption) => void;
+  showSortOptions?: boolean;
+  className?: string;
+}
+
+const SearchResultTitle = ({
+  totalCount,
+  initialSortOption = '신상품',
+  onSortChange,
+  showSortOptions = false,
+  className,
+}: SearchResultTitleProps) => {
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [selectedSort, setSelectedSort] = useState<SortOption>(initialSortOption);
+
+  const handleSortClick = () => {
+    setIsFilterOpen((prev) => !prev);
+  };
+
+  const handleSortOptionClick = (option: SortOption) => {
+    setSelectedSort(option);
+    setIsFilterOpen(false);
+    
+    if (onSortChange) {
+      onSortChange(option);
+    }
+  };
+  
+  // 정렬 옵션 드롭다운 렌더링
+  const renderSortOptions = () => {
+    if (!showSortOptions) return null;
+    
+    return (
+      <div css={S.sortOptionsContainerStyle}>
+        <button 
+          css={S.sortContainerStyle} 
+          onClick={handleSortClick}
+          aria-expanded={isFilterOpen}
+          aria-label={`${selectedSort} 정렬 옵션 선택하기`}
+          type="button"
+        >
+          <span css={S.sortTextStyle}>{selectedSort}</span>
+          <div css={S.iconContainerStyle}>
+            <SmallArrowDownIcon css={S.iconStyle} />
+          </div>
+        </button>
+
+        {isFilterOpen && (
+          <div css={S.dropdownStyle}>
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option}
+                css={S.optionButtonStyle(option === selectedSort)}
+                onClick={() => handleSortOptionClick(option)}
+                type="button"
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div css={S.containerStyle} className={className}>
+      <span css={S.countTextStyle}>총 {totalCount}개</span>
+      {renderSortOptions()}
+    </div>
+  );
+};
+
+export default SearchResultTitle;


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## 📌 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해 주세요. PR이 merge 되면 자동으로 해당 이슈가 닫힙니다. -->
- close #50

## 📄 작업 내용
<!-- 이번 PR에서 작업한 내용을 나열해 주세요. -->
- 매장 상품 찾기 페이지의 검색 결과 및 재고 정보 화면에서 사용할 SearchResultTitle 컴포넌트 구현
- 정렬 옵션(신상품/가격높은/가격낮은) 선택 드롭다운 구현

## 🔍 리뷰 포인트
<!-- 집중적으로 확인해야 할 부분이나 리뷰어에게 알려주고 싶은 내용이 있다면 작성해 주세요. -->
- 피그마 디자인에 맞게 UI가 구현되었는지 확인해 주세요 !
- 정렬 옵션 잘 동작하는지 봐주세요 !

## 📸 스크린샷 (선택)
<!-- UI 작업이 있는 경우 스크린샷을 첨부해 주세요. 없으면 비워두세요. -->
https://github.com/user-attachments/assets/929ed7f4-0ede-4b16-9451-4b833e9a98f2

## 사용 방법
### 1. 정렬 옵션이 있는 버전 (검색 결과 페이지에서 사용)
```tsx
<SearchResultTitle 
  totalCount={19} 
  showSortOptions={true}
  initialSortOption="신상품"
  onSortChange={(option) => {
    // 정렬 옵션 변경 처리
  }}
/>
```
### 2. 개수만 표시하는 버전 (재고 정보 페이지에서 사용)
```tsx
<SearchResultTitle` totalCount={3} />
```