### PR TITLE
[FEAT] 바텀 네비게이션 스크롤 반응형 동작 구현 #90

### DIFF
--- a/src/components/BottomNav/BottomNav.style.ts
+++ b/src/components/BottomNav/BottomNav.style.ts
@@ -2,9 +2,9 @@ import { css } from '@emotion/react';
 import theme from '@styles/theme';
 
 export const Wrapper = css`
-  display: fixed;
+  display: flex;
   justify-content: space-between;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
@@ -12,6 +12,7 @@ export const Wrapper = css`
   z-index: 100;
   border-top: 1px solid ${theme.colors['gray-05']};
   background: #fff;
+  transition: transform 0.3s ease-in-out;
 `;
 
 export const Container = css`

--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -9,10 +9,39 @@ import {
 } from '@assets/svgs';
 import * as S from './BottomNav.style';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+const BOTTOM_NAV_HEIGHT_REM = 5.6;
+const CIRCLE_BUTTON_OVER_REM = 3;
+const TOTAL_HIDE_HEIGHT_REM = BOTTOM_NAV_HEIGHT_REM + CIRCLE_BUTTON_OVER_REM;
 
 const BottomNav = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const [isVisible, setIsVisible] = useState(true);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      const scrollDifference = currentScrollY - lastScrollY;
+      
+      // 스크롤 차이가 10px 이상일 때만 동작하도록 설정
+      if (Math.abs(scrollDifference) > 10) {
+        if (scrollDifference > 0) {
+          // 스크롤 다운
+          setIsVisible(false);
+        } else {
+          // 스크롤 업
+          setIsVisible(true);
+        }
+        setLastScrollY(currentScrollY);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [lastScrollY]);
 
   // 현재 경로에 따라 탭 결정
   const getSelectedTab = () => {
@@ -25,7 +54,7 @@ const BottomNav = () => {
   const selectedTab = getSelectedTab();
 
   return (
-    <nav css={S.Wrapper}>
+    <nav css={[S.Wrapper, { transform: isVisible ? 'translateY(0)' : `translateY(${TOTAL_HIDE_HEIGHT_REM}rem)` }]}>
       <div css={S.Container}>
         <CategoryIconNew css={S.BasicIcon} />
         <p css={S.Caption}>카테고리</p>

--- a/src/components/ProductCard/ProductCardRanking/ProductCardRanking.style.ts
+++ b/src/components/ProductCard/ProductCardRanking/ProductCardRanking.style.ts
@@ -20,6 +20,7 @@ export const rankingContent = (hasCode?: boolean) => css`
   gap: ${hasCode ? '1.6rem' : '1.2rem'};
   flex: 1;
   min-width: 0;
+  max-height: 8.8rem;
   width: 100%;
   align-items: flex-start;
 `;
@@ -39,6 +40,7 @@ export const rankingImageWrapper = css`
   overflow: hidden;
   position: relative;
   max-height: 100%;
+  max-height: 8.8rem;
 `;
 
 export const rankingImage = css`

--- a/src/hooks/queries/useProductSortOptions.ts
+++ b/src/hooks/queries/useProductSortOptions.ts
@@ -1,9 +1,0 @@
-import { useQuery } from '@tanstack/react-query';
-import { getProductSortOptions } from '@apis/search/product';
-
-export const useProductSortOptions = (keyword: string) => 
-  useQuery<string[]>({
-    queryKey: ['productSortOptions', keyword],
-    queryFn: () => getProductSortOptions(keyword),
-    enabled: !!keyword, // 검색어가 있을 때만 쿼리 실행
-  });

--- a/src/pages/StoreSearchPage/SearchProductsSection.style.ts
+++ b/src/pages/StoreSearchPage/SearchProductsSection.style.ts
@@ -44,11 +44,22 @@ export const ProductCardWrapper = css`
   border: 1px solid var(--gray-05, #ebe9ee);
   background: #fff;
   box-sizing: border-box;
+  overflow: hidden;
 
   @media (max-width: 768px) {
     width: 100%;
     min-width: 0;
   }
+`;
+
+export const ProductCardContent = css`
+  display: flex;
+  align-items: flex-start;
+  gap: 1.6rem;
+  flex: 1 0 0;
+  min-width: 0;
+  min-height: 0;
+  max-height: 100%;
 `;
 
 export const LoadingContainer = css`

--- a/src/pages/StoreSearchPage/SearchProductsSection.tsx
+++ b/src/pages/StoreSearchPage/SearchProductsSection.tsx
@@ -1,4 +1,3 @@
-// src/pages/StoreSearchPage/SearchProductsSection.tsx
 import { useState, useEffect } from 'react';
 import * as S from './SearchProductsSection.style';
 import SearchBar from '@components/SearchBar/SearchBar';
@@ -129,7 +128,7 @@ const SearchProductsSection = ({
                 name={product.productName}
                 price={product.price.toLocaleString()}
                 code={product.productCode}
-                showCartIcon={true}
+                showCartIcon={false}
               />
             </div>
           ))}


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## 📌 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해 주세요. PR이 merge 되면 자동으로 해당 이슈가 닫힙니다. -->
- close #90

## 📄 작업 내용
<!-- 이번 PR에서 작업한 내용을 나열해 주세요. -->
- 바텀 네비게이션 스크롤 시 자동 숨김/표시 기능 구현
- 스크롤 다운 시 바텀 네비게이션 전체(튀어나온 버튼 포함) 아래로 완전히 숨김
- 스크롤 업 시 다시 자연스럽게 표시
- 홈/다른 모든 페이지에서 동일하게 동작
- 부드러운 애니메이션 효과 적용

## 🔍 리뷰 포인트
<!-- 집중적으로 확인해야 할 부분이나 리뷰어에게 알려주고 싶은 내용이 있다면 작성해 주세요. -->
- 바텀 네비게이션이 스크롤 방향에 따라 자연스럽게 사라지고 나타나는지 ~~~~~~
## 📸 스크린샷 (선택)
<!-- UI 작업이 있는 경우 스크린샷을 첨부해 주세요. 없으면 비워두세요. -->
Uploading 화면 기록 2025-05-23 오후 11.01.23.mov…